### PR TITLE
fix: fallback colors for radial gradients in MediaBackdropGradient

### DIFF
--- a/Shared/Views/Media/MediaBackdropGradient.swift
+++ b/Shared/Views/Media/MediaBackdropGradient.swift
@@ -4,6 +4,13 @@ struct MediaBackdropGradient: View {
     let colors: [Color]
 
     var body: some View {
+        let gradientColors = colors.count == 4 ? colors : [
+            Color.background.opacity(0.85),
+            Color.background.opacity(0.7),
+            Color.background.opacity(0.55),
+            Color.background.opacity(0.4),
+        ]
+
         GeometryReader { geo in
             ZStack {
                 Color(.background)
@@ -11,7 +18,7 @@ struct MediaBackdropGradient: View {
 
                 // Top Left
                 RadialGradient(
-                    gradient: Gradient(colors: [colors[0], .clear]),
+                    gradient: Gradient(colors: [gradientColors[0], .clear]),
                     center: .topLeading,
                     startRadius: 0,
                     endRadius: max(geo.size.width, geo.size.height) * 0.75,
@@ -19,7 +26,7 @@ struct MediaBackdropGradient: View {
 
                 // Top Right
                 RadialGradient(
-                    gradient: Gradient(colors: [colors[1], .clear]),
+                    gradient: Gradient(colors: [gradientColors[1], .clear]),
                     center: .topTrailing,
                     startRadius: 0,
                     endRadius: max(geo.size.width, geo.size.height) * 0.75,
@@ -27,7 +34,7 @@ struct MediaBackdropGradient: View {
 
                 // Bottom Right
                 RadialGradient(
-                    gradient: Gradient(colors: [colors[2], .clear]),
+                    gradient: Gradient(colors: [gradientColors[2], .clear]),
                     center: .bottomTrailing,
                     startRadius: 0,
                     endRadius: max(geo.size.width, geo.size.height) * 0.75,
@@ -35,7 +42,7 @@ struct MediaBackdropGradient: View {
 
                 // Bottom Left
                 RadialGradient(
-                    gradient: Gradient(colors: [colors[3], .clear]),
+                    gradient: Gradient(colors: [gradientColors[3], .clear]),
                     center: .bottomLeading,
                     startRadius: 0,
                     endRadius: max(geo.size.width, geo.size.height) * 0.75,


### PR DESCRIPTION
## Summary of Changes
This pull request updates the `MediaBackdropGradient` view to improve its handling of the `colors` array. Now, if fewer than four colors are provided, a default set of background colors with varying opacity is used to ensure consistent gradient rendering.

## Issues Fixed
#20 

## Screenshots/Video (if UI changes)
- 
