### PR TITLE
fix: tolerate Plex streams without IDs

### DIFF
--- a/Shared/Features/Player/PlayerViewModel.swift
+++ b/Shared/Features/Player/PlayerViewModel.swift
@@ -334,6 +334,7 @@ final class PlayerViewModel {
         guard
             let ffIndex = track.ffIndex,
             let stream = streamsByFFIndex[ffIndex],
+            let streamId = stream.id,
             let partId = activePartId
         else {
             return
@@ -345,12 +346,12 @@ final class PlayerViewModel {
             case .audio:
                 try await playbackRepository.setPreferredStreams(
                     partId: partId,
-                    audioStreamId: stream.id,
+                    audioStreamId: streamId,
                 )
             case .subtitle:
                 try await playbackRepository.setPreferredStreams(
                     partId: partId,
-                    subtitleStreamId: stream.id,
+                    subtitleStreamId: streamId,
                 )
             case .video:
                 break

--- a/Shared/Models/Plex/PlexMediaModels.swift
+++ b/Shared/Models/Plex/PlexMediaModels.swift
@@ -212,7 +212,7 @@ struct PlexPartStream: Codable, Equatable, Hashable {
         case subtitle = 3
     }
 
-    let id: Int
+    let id: Int?
     let index: Int?
     let codec: String
     let streamType: PlexPartStreamType


### PR DESCRIPTION
## Summary of Changes
- 

## Issues Fixed
- 

## Screenshots/Video (if UI changes)
- 
